### PR TITLE
RPD-3049 (Android) Change artifactid for apache's commons-io 

### DIFF
--- a/src/android/osappfeedback.gradle
+++ b/src/android/osappfeedback.gradle
@@ -8,7 +8,7 @@ repositories{
 dependencies {
    compile 'com.loopj.android:android-async-http:1.4.9'
    compile 'com.google.code.gson:gson:2.6.2'
-   compile 'org.apache.commons:commons-io:1.3.2'
+   compile 'commons-io:commons-io:1.3.2'
    compile(name:'MobileECT', ext:'aar')
 }
 


### PR DESCRIPTION
Context:
We were using the old artifactid, with that, when we have references for both artifacts, build gradle won't merge the duplicated dependencies properly