### PR TITLE
RNMT-2745 Add support for Cordova Android engine 7+

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -40,7 +40,7 @@
     <framework src="com.android.support:support-v4:23.+"/>
     
     <!-- App Feedback framework -->
-    <resource-file src="src/android/MobileECT/MobileECT.aar" target="MobileECT/MobileECT.aar" />
+    <resource-file src="src/android/MobileECT/MobileECT.aar" target="libs/MobileECT.aar" />
     
   </platform>
 

--- a/src/android/osappfeedback.gradle
+++ b/src/android/osappfeedback.gradle
@@ -1,7 +1,7 @@
 repositories{    
   jcenter()
   flatDir{
-      dirs 'MobileECT'
+      dirs 'libs','src/main/libs'
    }
 }
 


### PR DESCRIPTION
This pull request updates the target location of the _MobileECT.aar_ file in order to support Cordova Android engine 7+.

Jira issue: https://outsystemsrd.atlassian.net/browse/RNMT-2745