### PR TITLE
RNMT-3515 Listen to 2-finger long press and open ECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+- Register/unregister receiver in proper lifecycle callbacks [RNMT-3515](https://outsystemsrd.atlassian.net/browse/RNMT-3515)
+
 ### Additions
 - Opens ECT through broadcast gestures when targeting Android 10 and above [RNMT-3515](https://outsystemsrd.atlassian.net/browse/RNMT-3515)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Additions
+- Opens ECT through broadcast gestures when targeting Android 10 and above [RNMT-3515](https://outsystemsrd.atlassian.net/browse/RNMT-3515)
 
 ## [2.3.0]
 ### Additions

--- a/src/android/OSAppFeedback.java
+++ b/src/android/OSAppFeedback.java
@@ -15,7 +15,6 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
 import com.outsystems.android.mobileect.api.interfaces.OSECTProviderAPIHandler;
-import com.outsystems.plugins.broadcaster.constants.Constants;
 import com.outsystems.plugins.broadcaster.interfaces.Event;
 
 import org.apache.cordova.CallbackContext;
@@ -34,6 +33,18 @@ public class OSAppFeedback extends CordovaPlugin {
 
     private static final String DEFAULT_HOSTNAME = "DefaultHostname";
     private static final String DEFAULT_HANDLER = "DefaultAppFeedbackHandler";
+
+    // These constants match the ones defined in the Broadcaster plugin
+    // They are intended to use for MABS 6 only
+    // If any of these changes on Broadcaster plugin it should be reflected here
+    private static final String GESTURE_EVENT = "gestureEvent";
+    private static final String GESTURE_TYPE = "gestureType";
+    private static final String GESTURE_TAP = "gestureTap";
+    private static final String GESTURE_LONG_PRESS = "gestureLongPress";
+    private static final String GESTURE_NUMBER_FINGERS = "gestureNumberFingers";
+    private static final String GESTURE_ONE_FINGER = "1";
+    private static final String GESTURE_TWO_FINGERS = "2";
+    private static final String GESTURE_THREE_FINGERS = "3";
 
     private OSAppFeedbackListener appFeedbackListener;
 
@@ -249,12 +260,12 @@ public class OSAppFeedback extends CordovaPlugin {
                 public void onReceive(Context context, Intent intent) {
                     Bundle extras = intent.getExtras();
                     if(extras != null) {
-                        Event gestureEvent = extras.getParcelable(Constants.GESTURE_EVENT);
+                        Event gestureEvent = extras.getParcelable(GESTURE_EVENT);
                         if(gestureEvent != null) {
                             Map<String, String> eventData = gestureEvent.getData();
                             if(eventData != null) {
-                                if(Constants.GESTURE_LONG_PRESS.equals(eventData.get(Constants.GESTURE_TYPE)) &&
-                                        Constants.GESTURE_TWO_FINGERS.equals(eventData.get(Constants.GESTURE_NUMBER_FINGERS))) {
+                                if(GESTURE_LONG_PRESS.equals(eventData.get(GESTURE_TYPE)) &&
+                                        GESTURE_TWO_FINGERS.equals(eventData.get(GESTURE_NUMBER_FINGERS))) {
                                     cordovaActivity.runOnUiThread(new Runnable() {
                                         @Override
                                         public void run() {
@@ -275,7 +286,7 @@ public class OSAppFeedback extends CordovaPlugin {
                 }
             };
 
-            LocalBroadcastManager.getInstance(this.cordova.getActivity().getApplicationContext()).registerReceiver(broadcastReceiver, new IntentFilter(Constants.GESTURE_EVENT));
+            LocalBroadcastManager.getInstance(this.cordova.getActivity().getApplicationContext()).registerReceiver(broadcastReceiver, new IntentFilter(GESTURE_EVENT));
         }
         else {
             webView.getView().setOnTouchListener(new View.OnTouchListener() {

--- a/src/android/OSAppFeedback.java
+++ b/src/android/OSAppFeedback.java
@@ -1,12 +1,12 @@
 package com.outsystems.plugins.appfeedback;
 
-import android.app.Activity;
-import android.preference.Preference;
-import android.preference.PreferenceManager;
-import android.support.v4.view.GestureDetectorCompat;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.view.MotionEventCompat;
-import android.util.Log;
-import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,18 +14,19 @@ import android.webkit.WebView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
-import com.outsystems.android.mobileect.MobileECTController;
 import com.outsystems.android.mobileect.api.interfaces.OSECTProviderAPIHandler;
+import com.outsystems.plugins.broadcaster.constants.Constants;
+import com.outsystems.plugins.broadcaster.interfaces.Event;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaActivity;
 import org.apache.cordova.CordovaPlugin;
-import org.apache.cordova.CordovaPreferences;
 import org.apache.cordova.engine.SystemWebViewEngine;
 import org.json.JSONArray;
 import org.json.JSONException;
 
 import java.lang.ref.WeakReference;
+import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -242,39 +243,76 @@ public class OSAppFeedback extends CordovaPlugin {
     private void registerGestureHandler(){
         final CordovaActivity cordovaActivity = (CordovaActivity) cordova.getActivity();
 
-        webView.getView().setOnTouchListener(new View.OnTouchListener() {
-            @Override
-            public boolean onTouch(View v, MotionEvent event) {
-                int action = MotionEventCompat.getActionMasked(event);
+        if(cordovaActivity.getApplicationInfo().targetSdkVersion >= 29) {
+            BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
+                @Override
+                public void onReceive(Context context, Intent intent) {
+                    Bundle extras = intent.getExtras();
+                    if(extras != null) {
+                        Event gestureEvent = extras.getParcelable(Constants.GESTURE_EVENT);
+                        if(gestureEvent != null) {
+                            Map<String, String> eventData = gestureEvent.getData();
+                            if(eventData != null) {
+                                if(eventData.get(Constants.GESTURE_TYPE).equals(Constants.GESTURE_LONG_PRESS) &&
+                                        eventData.get(Constants.GESTURE_NUMBER_FINGERS).equals(Constants.GESTURE_TWO_FINGERS)) {
+                                    cordovaActivity.runOnUiThread(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            appFeedbackListener.handleECTAvailable(new OSECTProviderAPIHandler() {
+                                                @Override
+                                                public void execute(boolean result) {
+                                                    if(result) {
+                                                        appFeedbackListener.handleOpenECT(null);
+                                                    }
+                                                }
+                                            });
+                                        }
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            };
 
-                if(event.getPointerCount() == 2) {
-                    switch (action) {
-                        case MotionEvent.ACTION_POINTER_DOWN:
-                            mSecondFingerTimeDown = System.currentTimeMillis();
-                            mGestureRecognizerTimer = new Timer();
-                            mGestureRecognizerTimer.schedule(new GestureRecognizerTimedTask(cordovaActivity), INTERVAL_TO_SHOW_MENU);
-                            break;
-                        case MotionEvent.ACTION_POINTER_UP:
-                            if ((System.currentTimeMillis() - mSecondFingerTimeDown) <= INTERVAL_TO_SHOW_MENU) {
-                                mGestureRecognizerTimer.cancel();
-                            }
-                            if ((System.currentTimeMillis() - mSecondFingerTimeDown) >= INTERVAL_TO_SHOW_MENU) {
-                                mSecondFingerTimeDown = 0;
-                            }
-                            break;
+            LocalBroadcastManager.getInstance(this.cordova.getActivity().getApplicationContext()).registerReceiver(broadcastReceiver, new IntentFilter(Constants.GESTURE_EVENT));
+        }
+        else {
+            webView.getView().setOnTouchListener(new View.OnTouchListener() {
+                @Override
+                public boolean onTouch(View v, MotionEvent event) {
+                    int action = MotionEventCompat.getActionMasked(event);
+
+                    if(event.getPointerCount() == 2) {
+                        switch (action) {
+                            case MotionEvent.ACTION_POINTER_DOWN:
+                                mSecondFingerTimeDown = System.currentTimeMillis();
+                                mGestureRecognizerTimer = new Timer();
+                                mGestureRecognizerTimer.schedule(new GestureRecognizerTimedTask(cordovaActivity), INTERVAL_TO_SHOW_MENU);
+                                break;
+                            case MotionEvent.ACTION_POINTER_UP:
+                                if ((System.currentTimeMillis() - mSecondFingerTimeDown) <= INTERVAL_TO_SHOW_MENU) {
+                                    mGestureRecognizerTimer.cancel();
+                                }
+                                if ((System.currentTimeMillis() - mSecondFingerTimeDown) >= INTERVAL_TO_SHOW_MENU) {
+                                    mSecondFingerTimeDown = 0;
+                                }
+                                break;
+                        }
+
+                    }
+                    else{
+                        if(mGestureRecognizerTimer != null){
+                            mGestureRecognizerTimer.cancel();
+                        }
+                        mSecondFingerTimeDown = 0;
                     }
 
+                    return webView.getView().onTouchEvent(event);
                 }
-                else{
-                    if(mGestureRecognizerTimer != null){
-                        mGestureRecognizerTimer.cancel();
-                    }
-                    mSecondFingerTimeDown = 0;
-                }
+            });
+        }
 
-                return webView.getView().onTouchEvent(event);
-            }
-        });
     }
 
 }

--- a/src/android/OSAppFeedback.java
+++ b/src/android/OSAppFeedback.java
@@ -253,8 +253,8 @@ public class OSAppFeedback extends CordovaPlugin {
                         if(gestureEvent != null) {
                             Map<String, String> eventData = gestureEvent.getData();
                             if(eventData != null) {
-                                if(eventData.get(Constants.GESTURE_TYPE).equals(Constants.GESTURE_LONG_PRESS) &&
-                                        eventData.get(Constants.GESTURE_NUMBER_FINGERS).equals(Constants.GESTURE_TWO_FINGERS)) {
+                                if(Constants.GESTURE_LONG_PRESS.equals(eventData.get(Constants.GESTURE_TYPE)) &&
+                                        Constants.GESTURE_TWO_FINGERS.equals(eventData.get(Constants.GESTURE_NUMBER_FINGERS))) {
                                     cordovaActivity.runOnUiThread(new Runnable() {
                                         @Override
                                         public void run() {


### PR DESCRIPTION
## Description
<!--- Provide a small description of the problem in hands -->
Following https://github.com/OutSystems/cordova-outsystems-broadcaster/pull/17, this PR makes the App Feedback subscribe to gesture events and react when a 2-finger long press is broadcast.

This will only hold true when targeting Android 10 (API 29), otherwise the old mechanism is used.

See the commit messages for more information.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
References https://outsystemsrd.atlassian.net/browse/RNMT-3515

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected

- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Manual tests

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->
![demo_android](https://user-images.githubusercontent.com/996955/69545798-699cab00-0f8a-11ea-9a1c-2ccec40a2dc1.gif)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly