### PR TITLE
RNMT-5055 Update gradle to stop using the recently removed keyword 'compile'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changes
+- Update gradle to stop using the recently removed keyword 'compile' [RNMT-5055](https://outsystemsrd.atlassian.net/browse/RNMT-5055)
 ## Fixes
 - Update hooks to be compatible with Cordova CLI 10 [RNMT-4364](https://outsystemsrd.atlassian.net/browse/RNMT-4364)
 

--- a/src/android/osappfeedback.gradle
+++ b/src/android/osappfeedback.gradle
@@ -6,10 +6,10 @@ repositories{
 }
 
 dependencies {
-   compile 'com.loopj.android:android-async-http:1.4.9'
-   compile 'com.google.code.gson:gson:2.6.2'
-   compile 'commons-io:commons-io:1.3.2'
-   compile(name:'MobileECT', ext:'aar')
+   implementation 'com.loopj.android:android-async-http:1.4.9'
+   implementation 'com.google.code.gson:gson:2.6.2'
+   implementation 'commons-io:commons-io:1.3.2'
+   implementation(name:'MobileECT', ext:'aar')
 }
 
 android {


### PR DESCRIPTION
## Description
This pr replaces gradle keyword 'compile' for 'implementation'.

## Context
Check  ea39064 message for more information

References https://outsystemsrd.atlassian.net/browse/RNMT-5055

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected

- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests

## Screenshots (if appropriate)
Before:
![Screenshot 2021-08-02 at 17 07 19](https://user-images.githubusercontent.com/25803675/127895463-92f733ad-4812-4995-97d4-067b67f1b7f5.png)


After:
![Screenshot 2021-08-02 at 17 25 56](https://user-images.githubusercontent.com/25803675/127895475-d1f44f0a-28b2-4931-8b17-781cb9c0eaa7.png)


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly